### PR TITLE
[Design] 메인 대시보드 제작

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation("androidx.fragment:fragment-ktx:1.3.6")
+    implementation(project(":feature:dashBoard"))
     // Test dependencies
     androidTestImplementation(libs.androidx.test.ext)
     androidTestImplementation(libs.androidx.test.espresso.core)

--- a/core/ui/src/main/java/com/iguana/ui/BaseActivity.kt
+++ b/core/ui/src/main/java/com/iguana/ui/BaseActivity.kt
@@ -3,6 +3,8 @@ package com.iguana.ui
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.iguana.ui.databinding.ActivityBaseBinding
+import com.iguana.dashBoard.DashBoardFragment
+import com.iguana.ui.SideTabLayoutFragment
 
 class BaseActivity : AppCompatActivity() {
     private lateinit var binding: ActivityBaseBinding
@@ -15,7 +17,14 @@ class BaseActivity : AppCompatActivity() {
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, SideTabLayoutFragment())
+                .replace(R.id.content_frame, DashBoardFragment())
                 .commit()
         }
+    }
+
+    fun showDashBoard() {
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.content_frame, DashBoardFragment())
+            .commit()
     }
 }

--- a/core/ui/src/main/java/com/iguana/ui/SideTabLayoutFragment.kt
+++ b/core/ui/src/main/java/com/iguana/ui/SideTabLayoutFragment.kt
@@ -5,18 +5,40 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.iguana.ui.databinding.FragmentSideTabLayoutBinding
 
 class SideTabLayoutFragment : Fragment() {
+
     private var _binding: FragmentSideTabLayoutBinding? = null
     private val binding get() = _binding!!
 
+    private val _selectedItem = MutableLiveData<Int>(0)
+    val selectedItem: LiveData<Int> = _selectedItem
+
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         _binding = FragmentSideTabLayoutBinding.inflate(inflater, container, false)
+        binding.fragment = this
+        binding.lifecycleOwner = viewLifecycleOwner
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupClickListeners()
+    }
+
+    private fun setupClickListeners() {
+        binding.dashboard.setOnClickListener { onDashboardClick() }
+        binding.documents.setOnClickListener { onDocumentsClick() }
+        binding.favorites.setOnClickListener { onFavoritesClick() }
+        binding.profile.setOnClickListener { onProfileClick() }
+        binding.settings.setOnClickListener { onSettingsClick() }
     }
 
     override fun onDestroyView() {
@@ -25,22 +47,23 @@ class SideTabLayoutFragment : Fragment() {
     }
 
     fun onDashboardClick() {
-        // 나중에 DashboardFragment를 추가할 때 구현
+        _selectedItem.value = 0
+        (activity as? BaseActivity)?.showDashBoard()
     }
 
     fun onDocumentsClick() {
-        // 나중에 DocumentsFragment를 추가할 때 구현
+        _selectedItem.value = 1
     }
 
     fun onFavoritesClick() {
-        // 나중에 FavoritesFragment를 추가할 때 구현
+        _selectedItem.value = 2
     }
 
     fun onProfileClick() {
-        // 나중에 ProfileFragment를 추가할 때 구현
+        _selectedItem.value = 3
     }
 
     fun onSettingsClick() {
-        // 나중에 SettingsFragment를 추가할 때 구현
+        _selectedItem.value = 4
     }
 }

--- a/core/ui/src/main/res/layout-sw600dp/fragment_side_tab_layout.xml
+++ b/core/ui/src/main/res/layout-sw600dp/fragment_side_tab_layout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout>
-
     <data>
         <variable
             name="fragment"
@@ -29,7 +28,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:background="@drawable/nav_item_background"
+            android:selected="@{fragment.selectedItem == 0}"
+            android:onClick="@{() -> fragment.onDashboardClick()}">
 
             <ImageView
                 android:layout_width="24dp"
@@ -50,7 +52,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:background="@drawable/nav_item_background"
+            android:selected="@{fragment.selectedItem == 1}"
+            android:onClick="@{() -> fragment.onDocumentsClick()}">
 
             <ImageView
                 android:layout_width="24dp"
@@ -71,7 +76,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:background="@drawable/nav_item_background"
+            android:selected="@{fragment.selectedItem == 2}"
+            android:onClick="@{() -> fragment.onFavoritesClick()}">
 
             <ImageView
                 android:layout_width="24dp"
@@ -92,7 +100,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:background="@drawable/nav_item_background"
+            android:selected="@{fragment.selectedItem == 3}"
+            android:onClick="@{() -> fragment.onProfileClick()}">
 
             <ImageView
                 android:layout_width="24dp"
@@ -113,7 +124,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:background="@drawable/nav_item_background"
+            android:selected="@{fragment.selectedItem == 4}"
+            android:onClick="@{() -> fragment.onSettingsClick()}">
 
             <ImageView
                 android:layout_width="24dp"
@@ -127,10 +141,6 @@
                 android:layout_height="wrap_content"
                 android:text="설정"
                 android:paddingStart="8dp" />
-
         </LinearLayout>
-
-
     </LinearLayout>
-
 </layout>

--- a/core/ui/src/main/res/layout/fragment_side_tab_layout.xml
+++ b/core/ui/src/main/res/layout/fragment_side_tab_layout.xml
@@ -29,7 +29,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:onClick="@{() -> fragment.onDashboardClick()}">
 
             <ImageView
                 android:layout_width="24dp"
@@ -50,7 +51,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:onClick="@{() -> fragment.onDocumentsClick()}">
 
             <ImageView
                 android:layout_width="24dp"
@@ -71,7 +73,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:onClick="@{() -> fragment.onFavoritesClick()}">
 
             <ImageView
                 android:layout_width="24dp"
@@ -92,7 +95,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:onClick="@{() -> fragment.onProfileClick()}">
 
             <ImageView
                 android:layout_width="24dp"
@@ -113,7 +117,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="20dp">
+            android:padding="20dp"
+            android:onClick="@{() -> fragment.onSettingsClick()}">
 
             <ImageView
                 android:layout_width="24dp"

--- a/feature/dashBoard/build.gradle.kts
+++ b/feature/dashBoard/build.gradle.kts
@@ -3,11 +3,18 @@ plugins {
     id("iguana.android.hilt")
     id("iguana.kotlin.hilt")
     id("iguana.android.feature")
+    id("kotlin-kapt")
     alias(libs.plugins.kotlin.android)
 }
 
 android {
     namespace = "com.iguana.dashBoard"
+
+    buildFeatures {
+        viewBinding = true
+        dataBinding = true
+        buildConfig = true
+    }
 }
 dependencies {
     implementation(projects.core.domain)

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/AiHistoryAdapter.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/AiHistoryAdapter.kt
@@ -1,0 +1,28 @@
+package com.iguana.dashBoard
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.iguana.dashBoard.databinding.ItemAiHistoryBinding
+
+class AiHistoryAdapter(private val aiHistoryItems: List<AiHistoryItem>) :
+    RecyclerView.Adapter<AiHistoryAdapter.AiHistoryViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AiHistoryViewHolder {
+        val binding = ItemAiHistoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return AiHistoryViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: AiHistoryViewHolder, position: Int) {
+        holder.bind(aiHistoryItems[position])
+    }
+
+    override fun getItemCount(): Int = aiHistoryItems.size
+
+    class AiHistoryViewHolder(private val binding: ItemAiHistoryBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(aiHistoryItem: AiHistoryItem) {
+            binding.dateTextView.text = aiHistoryItem.date
+            binding.titleTextView.text = aiHistoryItem.title
+        }
+    }
+}

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/AiHistoryFragment.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/AiHistoryFragment.kt
@@ -1,0 +1,41 @@
+package com.iguana.dashBoard
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.iguana.dashBoard.databinding.FragmentAiHistoryBinding
+
+class AiHistoryFragment : Fragment() {
+    private var _binding: FragmentAiHistoryBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var aiHistoryAdapter: AiHistoryAdapter
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = FragmentAiHistoryBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+    }
+
+    private fun setupRecyclerView() {
+        aiHistoryAdapter = AiHistoryAdapter(emptyList())
+        binding.aiHistoryRecyclerView.apply {
+            layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+            adapter = aiHistoryAdapter
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}
+
+data class AiHistoryItem(val date: String, val title: String)

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/DashBoardFragment.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/DashBoardFragment.kt
@@ -1,0 +1,32 @@
+package com.iguana.dashBoard
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.iguana.dashBoard.databinding.FragmentDashBoardBinding
+
+class DashBoardFragment : Fragment() {
+    private var _binding: FragmentDashBoardBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = FragmentDashBoardBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        childFragmentManager.beginTransaction()
+            .replace(R.id.recent_files_container, RecentFilesFragment())
+            .replace(R.id.ai_history_container, AiHistoryFragment())
+            .commit()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesAdapter.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesAdapter.kt
@@ -1,0 +1,33 @@
+package com.iguana.dashBoard
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.iguana.dashBoard.databinding.ItemRecentFilesBinding
+
+class RecentFilesAdapter(private var recentFiles: List<RecentFile>) :
+    RecyclerView.Adapter<RecentFilesAdapter.RecentFileViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecentFileViewHolder {
+        val binding = ItemRecentFilesBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return RecentFileViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: RecentFileViewHolder, position: Int) {
+        holder.bind(recentFiles[position])
+    }
+
+    override fun getItemCount(): Int = recentFiles.size
+
+    fun updateData(newRecentFiles: List<RecentFile>) {
+        recentFiles = newRecentFiles
+        notifyDataSetChanged()
+    }
+
+    class RecentFileViewHolder(private val binding: ItemRecentFilesBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(recentFile: RecentFile) {
+            binding.fileName.text = recentFile.title
+            binding.fileTimestamp.text = recentFile.subtitle
+        }
+    }
+}

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesFragment.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesFragment.kt
@@ -1,0 +1,41 @@
+package com.iguana.dashBoard
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.iguana.dashBoard.databinding.FragmentRecentFilesBinding
+
+class RecentFilesFragment : Fragment() {
+    private var _binding: FragmentRecentFilesBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var recentFilesAdapter: RecentFilesAdapter
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = FragmentRecentFilesBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+    }
+
+    private fun setupRecyclerView() {
+        recentFilesAdapter = RecentFilesAdapter(emptyList())
+        binding.recentFilesRecyclerView.apply {
+            layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+            adapter = recentFilesAdapter
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}
+
+data class RecentFile(val title: String, val subtitle: String)

--- a/feature/dashBoard/src/main/res/layout-sw600dp/fragment_ai_history.xml
+++ b/feature/dashBoard/src/main/res/layout-sw600dp/fragment_ai_history.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="AI 요약"
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="AI로 생성했던 노트 요약과 문제를 모아 볼 수 있습니다."
+                        android:layout_marginStart="16dp" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="12dp"
+                        android:paddingVertical="12dp"
+                        android:background="@drawable/small_blue_button_background"
+                        android:layout_marginStart="16dp">
+
+                        <TextView
+                            android:id="@+id/buttonText"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="더보기"
+                            android:textColor="@color/white"
+                            style="@style/Regular8" />
+                    </LinearLayout>
+                </LinearLayout>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/ai_history_recycler_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_marginTop="16dp" />
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+    </LinearLayout>
+</layout>

--- a/feature/dashBoard/src/main/res/layout-sw600dp/fragment_dash_board.xml
+++ b/feature/dashBoard/src/main/res/layout-sw600dp/fragment_dash_board.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <!-- 상단 여백 추가 -->
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="80dp" />
+
+        <!-- 최근 파일 섹션 -->
+        <TextView
+            android:id="@+id/RecentstitleText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="최근 파일"
+            android:textColor="@android:color/black"
+            style="@style/Bold24" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray"
+            android:layout_marginTop="8dp" />
+
+        <FrameLayout
+            android:id="@+id/recent_files_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp">
+
+        </FrameLayout>
+
+        <!-- AI 히스토리 섹션 -->
+        <TextView
+            android:id="@+id/AItitleText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="AI 히스토리"
+            android:textColor="@android:color/black"
+            style="@style/Bold24"
+            android:layout_marginTop="32dp" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray"
+            android:layout_marginTop="8dp" />
+
+        <FrameLayout
+            android:id="@+id/ai_history_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp" />
+
+    </LinearLayout>
+</layout>

--- a/feature/dashBoard/src/main/res/layout-sw600dp/fragment_recent_files.xml
+++ b/feature/dashBoard/src/main/res/layout-sw600dp/fragment_recent_files.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="160dp"
+                android:layout_height="200dp"
+                android:background="@drawable/file_item_background"
+                android:elevation="2dp"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:padding="16dp"
+                android:layout_margin="10dp"
+                tools:ignore="MissingDefaultResource">
+
+                <!-- Plus 아이콘 -->
+                <ImageView
+                    android:id="@+id/plusIcon"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_plus48_inactive" />
+
+                <!-- 텍스트 정보 -->
+                <TextView
+                    android:id="@+id/loadLectureText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:gravity="center"
+                    android:text="강의자료 불러오기"
+                    style="@style/Regular8"
+                    />
+            </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recent_files_recycler_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="4"
+            android:orientation="horizontal" />
+
+    </LinearLayout>
+</layout>

--- a/feature/dashBoard/src/main/res/layout/fragment_ai_history.xml
+++ b/feature/dashBoard/src/main/res/layout/fragment_ai_history.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="AI 요약"
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="AI로 생성했던 노트 요약과 문제를 모아 볼 수 있습니다."
+                        android:layout_marginStart="16dp" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="12dp"
+                        android:paddingVertical="12dp"
+                        android:background="@drawable/small_blue_button_background"
+                        android:layout_marginStart="16dp">
+
+                        <TextView
+                            android:id="@+id/buttonText"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="더보기"
+                            android:textColor="@color/white"
+                            style="@style/Regular8" />
+                    </LinearLayout>
+                </LinearLayout>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/ai_history_recycler_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_marginTop="16dp" />
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+    </LinearLayout>
+</layout>

--- a/feature/dashBoard/src/main/res/layout/fragment_dash_board.xml
+++ b/feature/dashBoard/src/main/res/layout/fragment_dash_board.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <!-- 상단 여백 추가 -->
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="80dp" />
+
+        <!-- 최근 파일 섹션 -->
+        <TextView
+            android:id="@+id/RecentstitleText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="최근 파일"
+            android:textColor="@android:color/black"
+            style="@style/Bold24" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray"
+            android:layout_marginTop="8dp" />
+
+        <FrameLayout
+            android:id="@+id/recent_files_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp">
+
+        </FrameLayout>
+
+        <!-- AI 히스토리 섹션 -->
+        <TextView
+            android:id="@+id/AItitleText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="AI 히스토리"
+            android:textColor="@android:color/black"
+            style="@style/Bold24"
+            android:layout_marginTop="32dp" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray"
+            android:layout_marginTop="8dp" />
+
+        <FrameLayout
+            android:id="@+id/ai_history_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp" />
+
+    </LinearLayout>
+</layout>

--- a/feature/dashBoard/src/main/res/layout/fragment_recent_files.xml
+++ b/feature/dashBoard/src/main/res/layout/fragment_recent_files.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="160dp"
+            android:layout_height="200dp"
+            android:background="@drawable/file_item_background"
+            android:elevation="2dp"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:layout_margin="10dp"
+            tools:ignore="MissingDefaultResource">
+
+            <!-- Plus 아이콘 -->
+            <ImageView
+                android:id="@+id/plusIcon"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_plus48_inactive" />
+
+            <!-- 텍스트 정보 -->
+            <TextView
+                android:id="@+id/loadLectureText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:gravity="center"
+                android:text="강의자료 불러오기"
+                style="@style/Regular8"
+                />
+        </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recent_files_recycler_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="4"
+            android:orientation="horizontal" />
+
+    </LinearLayout>
+</layout>

--- a/feature/dashBoard/src/main/res/layout/item_ai_history.xml
+++ b/feature/dashBoard/src/main/res/layout/item_ai_history.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/dateTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="12sp" />
+
+    <TextView
+        android:id="@+id/titleTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        android:layout_marginTop="4dp" />
+</LinearLayout>

--- a/feature/dashBoard/src/main/res/layout/item_recent_files.xml
+++ b/feature/dashBoard/src/main/res/layout/item_recent_files.xml
@@ -1,0 +1,60 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="160dp"
+    android:layout_height="200dp"
+    android:orientation="vertical"
+    android:elevation="4dp"
+    android:background="@drawable/file_item_background"
+    android:layout_margin="10dp"
+    tools:ignore="MissingDefaultResource">
+
+    <!-- 상단 색상 및 책갈피 아이콘 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        android:gravity="end">
+
+        <ImageView
+            android:id="@+id/bookmarkIcon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="end|top"
+            android:layout_marginTop="10dp"
+            android:layout_marginRight="10dp"
+            android:src="@drawable/ic_file_saved_inactive" />
+    </LinearLayout>
+
+    <!-- 파일 정보 텍스트 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:paddingBottom="20dp"
+        android:paddingTop="8dp"
+        android:orientation="vertical">
+
+        <!-- 제목 텍스트, 줄이 넘치면 '...' 표시 -->
+        <TextView
+            android:id="@+id/fileName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="DeepLearning (1)"
+            android:textStyle="bold"
+            style="@style/Regular8"
+            android:textColor="@android:color/black"
+            android:maxLines="1"
+            android:ellipsize="end" /> <!-- 줄이 넘치면 ... 표시 -->
+
+        <!-- 타임스탬프 텍스트 -->
+        <TextView
+            android:id="@+id/fileTimestamp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="24.09.04.15:20"
+            style="@style/Regular6"
+            android:textColor="@android:color/darker_gray" />
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## 🔎 작업 내용

- 대시보드 xml을 제작하여 대시보드 초기 화면을 구상하였습니다.
- 모킹 작업 이후 파일들이 어떻게 표시되는지에 따라 디자인을 다시 손 볼 것 같습니다.
- Fragment에 계속 붙이느라 작업 단위가 길어져 커밋을 하나밖에 못했습니다. 보기 불편하시다면 죄송합니다!


## 💬 리뷰 요구사항 (선택)

> 설정 부분 selector가 활성화 되면, Edit 부분 (연필 로고)가 나오게 되는데, 이게 의도 된 것인지 모르겠어서 일단 고치지 않고 그대로 사용했습니다.


## 📸 이미지 첨부 (선택)
![KakaoTalk_20240926_205147933](https://github.com/user-attachments/assets/07869f35-b0f9-469b-ba79-3b2f58575350)

## ➕ 이슈 링크
- #16 
- [[Design] 메인 대시보드 XML 제작 #16](https://github.com/kakao-tech-campus-2nd-step3/Team29_Android/issues/16)
