### PR TITLE
[Feat]  PDF 파일 Room DB 에 저장

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -42,12 +42,12 @@
               <deviceKey>
                 <Key>
                   <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="$USER_HOME$/.android/avd/Pixel_Tablet_API_33_2.avd" />
+                  <value value="$USER_HOME$/.android/avd/Pixel_Tablet_API_33.avd" />
                 </Key>
               </deviceKey>
             </Target>
           </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-09-30T02:00:26.529580Z" />
+          <timeTargetWasSelectedWithDropDown value="2024-09-25T11:00:16.444094Z" />
         </State>
       </entry>
     </value>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -42,12 +42,12 @@
               <deviceKey>
                 <Key>
                   <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="$USER_HOME$/.android/avd/Pixel_Tablet_API_33.avd" />
+                  <value value="$USER_HOME$/.android/avd/Medium_Tablet_API_33.avd" />
                 </Key>
               </deviceKey>
             </Target>
           </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-09-25T11:00:16.444094Z" />
+          <timeTargetWasSelectedWithDropDown value="2024-09-30T18:20:24.641110Z" />
         </State>
       </entry>
     </value>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -42,12 +42,12 @@
               <deviceKey>
                 <Key>
                   <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="$USER_HOME$/.android/avd/Pixel_Tablet_API_33.avd" />
+                  <value value="$USER_HOME$/.android/avd/Pixel_Tablet_API_33_2.avd" />
                 </Key>
               </deviceKey>
             </Target>
           </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-09-25T11:00:16.444094Z" />
+          <timeTargetWasSelectedWithDropDown value="2024-09-30T02:00:26.529580Z" />
         </State>
       </entry>
     </value>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
         <activity
             android:name="com.iguana.login.LoginActivity"
             android:exported="true">
+        </activity>
+        <activity
+            android:name="com.iguana.notetaking.SampleFilePickerActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
             android:name=".DesignSampleActivity"
             android:exported="false" />
         <activity
-            android:name="com.iguana.notetaking.SampleFilePickerActivity"
+            android:name="com.iguana.login.LoginActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/core/data/src/main/java/com/iguana/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/iguana/data/di/DataModule.kt
@@ -26,13 +26,13 @@ abstract class DataModule {
     @Singleton
     abstract fun bindLoginRepository(
         loginRepositoryImpl: LoginRepositoryImpl
-    ): com.iguana.domain.repository.LoginRepository
+    ): LoginRepository
 
     @Binds
     @Singleton
     abstract fun bindSharedPreferencesHelper(
         sharedPreferencesHelperImpl: SharedPreferencesHelperImpl
-    ): com.iguana.domain.repository.SharedPreferencesHelper
+    ): SharedPreferencesHelper
 
     @Binds
     @Singleton

--- a/core/data/src/main/java/com/iguana/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/iguana/data/di/DataModule.kt
@@ -8,6 +8,8 @@ import com.iguana.data.repository.LoginRepositoryImpl
 import com.iguana.domain.repository.LoginRepository
 import com.iguana.domain.repository.SharedPreferencesHelper
 import com.iguana.data.local.db.SharedPreferencesHelperImpl
+import com.iguana.data.repository.RecentFileRepositoryImpl
+import com.iguana.domain.repository.RecentFileRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -31,6 +33,12 @@ abstract class DataModule {
     abstract fun bindSharedPreferencesHelper(
         sharedPreferencesHelperImpl: SharedPreferencesHelperImpl
     ): com.iguana.domain.repository.SharedPreferencesHelper
+
+    @Binds
+    @Singleton
+    abstract fun bindRecentFileRepository(
+        recentFileRepositoryImpl: RecentFileRepositoryImpl
+    ): RecentFileRepository
 
     companion object {
         @Provides

--- a/core/data/src/main/java/com/iguana/data/local/dao/RecentFileDao.kt
+++ b/core/data/src/main/java/com/iguana/data/local/dao/RecentFileDao.kt
@@ -18,6 +18,9 @@ interface RecentFileDao {
     @Update
     fun updateRecentFile(recentFile: RecentFileEntity)
 
+    @Query("UPDATE recent_files SET lastOpened = :lastOpened WHERE id = :id")
+    fun updateLastOpened(id: String, lastOpened: Long)
+
     @Delete
     fun deleteRecentFile(recentFile: RecentFileEntity)
 

--- a/core/data/src/main/java/com/iguana/data/local/dao/RecentFileDao.kt
+++ b/core/data/src/main/java/com/iguana/data/local/dao/RecentFileDao.kt
@@ -19,7 +19,7 @@ interface RecentFileDao {
     fun updateRecentFile(recentFile: RecentFileEntity)
 
     @Query("UPDATE recent_files SET lastOpened = :lastOpened WHERE id = :id")
-    fun updateLastOpened(id: String, lastOpened: Long)
+    fun updateLastOpened(id: String, lastOpened: Long): Int
 
     @Delete
     fun deleteRecentFile(recentFile: RecentFileEntity)

--- a/core/data/src/main/java/com/iguana/data/local/db/AppDatabase.kt
+++ b/core/data/src/main/java/com/iguana/data/local/db/AppDatabase.kt
@@ -4,24 +4,42 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.iguana.data.local.dao.RecentFileDao
 import com.iguana.data.local.entity.RecentFileEntity
 
-@Database(entities = [RecentFileEntity::class], version = 1, exportSchema = false)
+@Database(entities = [RecentFileEntity::class], version = 2, exportSchema = true)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun recentFileDao(): RecentFileDao
 
     companion object {
+        private const val DATABASE_NAME = "app_database"
+
         @Volatile
         private var INSTANCE: AppDatabase? = null
+
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("SELECT 1")
+            }
+        }
 
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     AppDatabase::class.java,
-                    "app_database"
-                ).build()
+                    DATABASE_NAME
+                )
+                    .addMigrations(MIGRATION_1_2)
+                    .fallbackToDestructiveMigration()
+                    .addCallback(object : RoomDatabase.Callback() {
+                        override fun onCreate(db: SupportSQLiteDatabase) {
+                            super.onCreate(db)
+                        }
+                    })
+                    .build()
                 INSTANCE = instance
                 instance
             }

--- a/core/data/src/main/java/com/iguana/data/local/db/SharedPreferencesHelperImpl.kt
+++ b/core/data/src/main/java/com/iguana/data/local/db/SharedPreferencesHelperImpl.kt
@@ -2,6 +2,7 @@ package com.iguana.data.local.db
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.iguana.domain.repository.SharedPreferencesHelper
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -9,7 +10,7 @@ import javax.inject.Singleton
 @Singleton
 class SharedPreferencesHelperImpl @Inject constructor(
     @ApplicationContext context: Context
-) : com.iguana.domain.repository.SharedPreferencesHelper {
+) : SharedPreferencesHelper {
 
     companion object {
         private const val PREFS_NAME = "login_prefs"

--- a/core/data/src/main/java/com/iguana/data/local/entity/RecentFileEntity.kt
+++ b/core/data/src/main/java/com/iguana/data/local/entity/RecentFileEntity.kt
@@ -1,13 +1,14 @@
 package com.iguana.data.local.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
 @Entity(tableName = "recent_files")
 data class RecentFileEntity(
     @PrimaryKey val id: String,
-    val fileName: String,
-    val fileUri: String,
-    val lastOpened: Long,
-    val bookmarkedPage: Int?
+    @ColumnInfo(name = "fileName") val fileName: String,
+    @ColumnInfo(name = "fileUri") val fileUri: String,
+    @ColumnInfo(name = "lastOpened") val lastOpened: Long,
+    @ColumnInfo(name = "bookmarkedPage") val bookmarkedPage: Int?
 )

--- a/core/data/src/main/java/com/iguana/data/mapper/RecentFileMapper.kt
+++ b/core/data/src/main/java/com/iguana/data/mapper/RecentFileMapper.kt
@@ -1,0 +1,26 @@
+package com.iguana.data.mapper
+
+import com.iguana.data.local.entity.RecentFileEntity
+import com.iguana.domain.model.RecentFile
+
+// Entity -> Domain Model로 변환
+fun RecentFileEntity.toDomainModel(): RecentFile {
+    return RecentFile(
+        id = this.id,
+        fileName = this.fileName,
+        fileUri = this.fileUri,
+        lastOpened = this.lastOpened,
+        bookmarkedPage = this.bookmarkedPage
+    )
+}
+
+// Domain Model -> Entity로 변환
+fun RecentFile.toEntity(): RecentFileEntity {
+    return RecentFileEntity(
+        id = this.id,
+        fileName = this.fileName,
+        fileUri = this.fileUri,
+        lastOpened = this.lastOpened,
+        bookmarkedPage = this.bookmarkedPage
+    )
+}

--- a/core/data/src/main/java/com/iguana/data/repository/LoginRepositorylmpl.kt
+++ b/core/data/src/main/java/com/iguana/data/repository/LoginRepositorylmpl.kt
@@ -2,6 +2,7 @@ package com.iguana.data.repository
 
 import com.iguana.data.remote.api.LoginApi
 import com.iguana.data.remote.api.KakaoTokenRequest
+import com.iguana.domain.repository.LoginRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -11,7 +12,7 @@ import javax.inject.Singleton
 class LoginRepositoryImpl @Inject constructor(
     private val loginApi: LoginApi,
     private val sharedPreferencesHelper: com.iguana.domain.repository.SharedPreferencesHelper
-) : com.iguana.domain.repository.LoginRepository {
+) : LoginRepository {
 
     override suspend fun getKakaoLoginUrl(): String? = withContext(Dispatchers.IO) {
         try {

--- a/core/data/src/main/java/com/iguana/data/repository/RecentFileRepositoryImpl.kt
+++ b/core/data/src/main/java/com/iguana/data/repository/RecentFileRepositoryImpl.kt
@@ -2,24 +2,31 @@ package com.iguana.data.repository
 
 import com.iguana.data.local.dao.RecentFileDao
 import com.iguana.data.local.entity.RecentFileEntity
+import com.iguana.data.mapper.toDomainModel
+import com.iguana.data.mapper.toEntity
+import com.iguana.domain.model.RecentFile
 import com.iguana.domain.repository.RecentFileRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class RecentFileRepositoryImpl @Inject constructor(
     private val recentFileDao: RecentFileDao
-): RecentFileRepository {
+) : RecentFileRepository {
     override suspend fun insertRecentFile(id: String, fileName: String, fileUri: String) {
         withContext(Dispatchers.IO) {
-            val recentFile = RecentFileEntity(id, fileName, fileUri, System.currentTimeMillis(), null)
-            recentFileDao.insertRecentFile(recentFile)
+            val recentFileEntity =
+                RecentFileEntity(id, fileName, fileUri, System.currentTimeMillis(), null)
+            recentFileDao.insertRecentFile(recentFileEntity)
         }
     }
 
-    override fun getRecentFiles(): Flow<List<RecentFileEntity>> {
-        return recentFileDao.getRecentFiles()
+    override fun getRecentFiles(): Flow<List<RecentFile>> {
+        return recentFileDao.getRecentFiles().map {
+            it.map { it.toDomainModel() }
+        }
     }
 
     override suspend fun updateBookmark(fileId: String, bookmarkedPage: Int) {
@@ -30,8 +37,8 @@ class RecentFileRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deleteRecentFile(recentFile: RecentFileEntity) {
-        recentFileDao.deleteRecentFile(recentFile)
+    override suspend fun deleteRecentFile(recentFile: RecentFile) {
+        recentFileDao.deleteRecentFile(recentFile.toEntity())
     }
 
     override suspend fun cleanupOldFiles(daysToKeep: Int) {

--- a/core/data/src/main/java/com/iguana/data/repository/RecentFileRepositoryImpl.kt
+++ b/core/data/src/main/java/com/iguana/data/repository/RecentFileRepositoryImpl.kt
@@ -1,27 +1,28 @@
-package com.iguana.data.local.repository
+package com.iguana.data.repository
 
 import com.iguana.data.local.dao.RecentFileDao
 import com.iguana.data.local.entity.RecentFileEntity
+import com.iguana.domain.repository.RecentFileRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class RecentFileRepository @Inject constructor(
+class RecentFileRepositoryImpl @Inject constructor(
     private val recentFileDao: RecentFileDao
-) {
-    suspend fun insertRecentFile(id: String, fileName: String, fileUri: String) {
+): RecentFileRepository {
+    override suspend fun insertRecentFile(id: String, fileName: String, fileUri: String) {
         withContext(Dispatchers.IO) {
             val recentFile = RecentFileEntity(id, fileName, fileUri, System.currentTimeMillis(), null)
             recentFileDao.insertRecentFile(recentFile)
         }
     }
 
-    fun getRecentFiles(): Flow<List<RecentFileEntity>> {
+    override fun getRecentFiles(): Flow<List<RecentFileEntity>> {
         return recentFileDao.getRecentFiles()
     }
 
-    suspend fun updateBookmark(fileId: String, bookmarkedPage: Int) {
+    override suspend fun updateBookmark(fileId: String, bookmarkedPage: Int) {
         val recentFile = recentFileDao.getRecentFileById(fileId)
         recentFile?.let {
             val updatedFile = it.copy(bookmarkedPage = bookmarkedPage)
@@ -29,11 +30,11 @@ class RecentFileRepository @Inject constructor(
         }
     }
 
-    suspend fun deleteRecentFile(recentFile: RecentFileEntity) {
+    override suspend fun deleteRecentFile(recentFile: RecentFileEntity) {
         recentFileDao.deleteRecentFile(recentFile)
     }
 
-    suspend fun cleanupOldFiles(daysToKeep: Int) {
+    override suspend fun cleanupOldFiles(daysToKeep: Int) {
         val cutoffTime = System.currentTimeMillis() - (daysToKeep * 24 * 60 * 60 * 1000L)
         recentFileDao.deleteOldFiles(cutoffTime)
     }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -6,5 +6,5 @@ android {
     namespace = "com.iguana.domain"
 }
 dependencies {
-
+    implementation(projects.core.data)
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -6,5 +6,4 @@ android {
     namespace = "com.iguana.domain"
 }
 dependencies {
-    implementation(projects.core.data)
 }

--- a/core/domain/src/main/java/com/iguana/domain/model/RecentFile.kt
+++ b/core/domain/src/main/java/com/iguana/domain/model/RecentFile.kt
@@ -1,0 +1,9 @@
+package com.iguana.domain.model
+
+data class RecentFile(
+    val id: String,
+    val fileName: String,
+    val fileUri: String,
+    val lastOpened: Long,
+    val bookmarkedPage: Int?
+)

--- a/core/domain/src/main/java/com/iguana/domain/repository/RecentFileRepository.kt
+++ b/core/domain/src/main/java/com/iguana/domain/repository/RecentFileRepository.kt
@@ -1,0 +1,12 @@
+package com.iguana.domain.repository
+
+import com.iguana.data.local.entity.RecentFileEntity
+import kotlinx.coroutines.flow.Flow
+
+interface RecentFileRepository {
+    suspend fun insertRecentFile(id: String, fileName: String, fileUri: String)
+    fun getRecentFiles(): Flow<List<RecentFileEntity>>
+    suspend fun updateBookmark(fileId: String, bookmarkedPage: Int)
+    suspend fun deleteRecentFile(recentFile: RecentFileEntity)
+    suspend fun cleanupOldFiles(daysToKeep: Int)
+}

--- a/core/domain/src/main/java/com/iguana/domain/repository/RecentFileRepository.kt
+++ b/core/domain/src/main/java/com/iguana/domain/repository/RecentFileRepository.kt
@@ -1,12 +1,12 @@
 package com.iguana.domain.repository
 
-import com.iguana.data.local.entity.RecentFileEntity
+import com.iguana.domain.model.RecentFile
 import kotlinx.coroutines.flow.Flow
 
 interface RecentFileRepository {
     suspend fun insertRecentFile(id: String, fileName: String, fileUri: String)
-    fun getRecentFiles(): Flow<List<RecentFileEntity>>
+    fun getRecentFiles(): Flow<List<RecentFile>>
     suspend fun updateBookmark(fileId: String, bookmarkedPage: Int)
-    suspend fun deleteRecentFile(recentFile: RecentFileEntity)
+    suspend fun deleteRecentFile(recentFile: RecentFile)
     suspend fun cleanupOldFiles(daysToKeep: Int)
 }

--- a/core/domain/src/main/java/com/iguana/domain/usecase/LoginUsecase.kt
+++ b/core/domain/src/main/java/com/iguana/domain/usecase/LoginUsecase.kt
@@ -1,3 +1,0 @@
-package com.iguana.domain.usecase
-
-// NOTE : 로그인 유스케이스 (사용 안하면 삭제)

--- a/core/domain/src/main/java/com/iguana/domain/usecase/SaveRecentFileUsecase.kt
+++ b/core/domain/src/main/java/com/iguana/domain/usecase/SaveRecentFileUsecase.kt
@@ -1,5 +1,12 @@
 package com.iguana.domain.usecase
 
-class SaveRecentFileUsecase {
+import com.iguana.domain.repository.RecentFileRepository
+import javax.inject.Inject
 
+class SaveRecentFileUsecase @Inject constructor(
+    private val recentFileRepository: RecentFileRepository
+) {
+    suspend operator fun invoke(id: String, fileName: String, fileUri: String) {
+        recentFileRepository.insertRecentFile(id, fileName, fileUri)
+    }
 }

--- a/core/domain/src/main/java/com/iguana/domain/usecase/SaveRecentFileUsecase.kt
+++ b/core/domain/src/main/java/com/iguana/domain/usecase/SaveRecentFileUsecase.kt
@@ -1,0 +1,5 @@
+package com.iguana.domain.usecase
+
+class SaveRecentFileUsecase {
+
+}

--- a/core/ui/src/main/java/com/iguana/ui/BaseActivity.kt
+++ b/core/ui/src/main/java/com/iguana/ui/BaseActivity.kt
@@ -2,8 +2,8 @@ package com.iguana.ui
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.iguana.dashBoard.DashBoardFragment
 import com.iguana.ui.databinding.ActivityBaseBinding
-import com.iguana.dashboard.DashBoardFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/feature/dashBoard/build.gradle.kts
+++ b/feature/dashBoard/build.gradle.kts
@@ -24,7 +24,9 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation(projects.core.data)
-    implementation("androidx.fragment:fragment-ktx:1.5.5")
+    implementation(libs.pdfbox)
+    implementation(libs.androidx.fragment.ktx)
+    implementation(projects.feature.notetaking)
 
     // Test dependencies
     androidTestImplementation(libs.androidx.test.ext)

--- a/feature/dashBoard/src/androidTest/java/com/iguana/dashBoard/ExampleInstrumentedTest.kt
+++ b/feature/dashBoard/src/androidTest/java/com/iguana/dashBoard/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package com.iguana.dashboard
+package com.iguana.dashBoard
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/feature/dashBoard/src/main/AndroidManifest.xml
+++ b/feature/dashBoard/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application>
         <activity
-            android:name="com.iguana.dashboard.DashBoradFragment"
+            android:name="com.iguana.dashBoard.DashBoradFragment"
             android:exported="false" />
     </application>
 

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/AiHistoryAdapter.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/AiHistoryAdapter.kt
@@ -1,10 +1,9 @@
-package com.iguana.dashboard
+package com.iguana.dashBoard
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.iguana.dashBoard.databinding.ItemAiHistoryBinding
-
 class AiHistoryAdapter(private val aiHistoryItems: List<AiHistoryItem>) :
     RecyclerView.Adapter<AiHistoryAdapter.AiHistoryViewHolder>() {
 

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/AiHistoryFragment.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/AiHistoryFragment.kt
@@ -1,4 +1,4 @@
-package com.iguana.dashboard
+package com.iguana.dashBoard
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/DashBoardFragment.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/DashBoardFragment.kt
@@ -1,4 +1,4 @@
-package com.iguana.dashboard
+package com.iguana.dashBoard
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.iguana.dashBoard.R
 import com.iguana.dashBoard.databinding.FragmentDashBoardBinding
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/DashBoardViewModel.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/DashBoardViewModel.kt
@@ -3,7 +3,8 @@ package com.iguana.dashboard
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.iguana.data.local.entity.RecentFileEntity
-import com.iguana.data.local.repository.RecentFileRepository
+import com.iguana.domain.model.RecentFile
+import com.iguana.domain.repository.RecentFileRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,8 +17,8 @@ class DashBoardViewModel @Inject constructor(
     private val recentFileRepository: RecentFileRepository
 ) : ViewModel() {
 
-    private val _recentFiles = MutableStateFlow<List<RecentFileEntity>>(emptyList())
-    val recentFiles: StateFlow<List<RecentFileEntity>> = _recentFiles.asStateFlow()
+    private val _recentFiles = MutableStateFlow<List<RecentFile>>(emptyList())
+    val recentFiles: StateFlow<List<RecentFile>> = _recentFiles.asStateFlow()
 
     init {
         loadRecentFiles()

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/DashBoardViewModel.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/DashBoardViewModel.kt
@@ -1,4 +1,4 @@
-package com.iguana.dashboard
+package com.iguana.dashBoard
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesAdapter.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesAdapter.kt
@@ -5,8 +5,9 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.iguana.dashBoard.databinding.ItemRecentFilesBinding
 import com.iguana.data.local.entity.RecentFileEntity
+import com.iguana.domain.model.RecentFile
 
-class RecentFilesAdapter(private var recentFiles: List<RecentFileEntity> = emptyList()) :
+class RecentFilesAdapter(private var recentFiles: List<RecentFile> = emptyList()) :
     RecyclerView.Adapter<RecentFilesAdapter.RecentFileViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecentFileViewHolder {
@@ -20,13 +21,13 @@ class RecentFilesAdapter(private var recentFiles: List<RecentFileEntity> = empty
 
     override fun getItemCount(): Int = recentFiles.size
 
-    fun updateData(newRecentFiles: List<RecentFileEntity>) {
+    fun updateData(newRecentFiles: List<RecentFile>) {
         recentFiles = newRecentFiles
         notifyDataSetChanged()
     }
 
     class RecentFileViewHolder(private val binding: ItemRecentFilesBinding) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(recentFile: RecentFileEntity) {
+        fun bind(recentFile: RecentFile) {
             binding.fileName.text = recentFile.fileName
             binding.fileTimestamp.text = formatLastOpened(recentFile.lastOpened)
         }

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesAdapter.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesAdapter.kt
@@ -1,4 +1,4 @@
-package com.iguana.dashboard
+package com.iguana.dashBoard
 
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesFragment.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesFragment.kt
@@ -1,4 +1,4 @@
-package com.iguana.dashboard
+package com.iguana.dashBoard
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesFragment.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesFragment.kt
@@ -1,9 +1,14 @@
 package com.iguana.dashBoard
 
+import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -22,6 +27,8 @@ class RecentFilesFragment : Fragment() {
     private val viewModel: RecentFilesViewModel by viewModels()
     private lateinit var recentFilesAdapter: RecentFilesAdapter
 
+    private lateinit var openPdfLauncher: ActivityResultLauncher<Array<String>>
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentRecentFilesBinding.inflate(inflater, container, false)
         return binding.root
@@ -32,6 +39,11 @@ class RecentFilesFragment : Fragment() {
 
         setupRecentFilesRecyclerView()
         observeRecentFiles()
+        setupFilePicker()
+
+        binding.plusIcon.setOnClickListener {
+            openPdfLauncher.launch(arrayOf("application/pdf"))
+        }
     }
 
     private fun setupRecentFilesRecyclerView() {
@@ -48,6 +60,16 @@ class RecentFilesFragment : Fragment() {
                 viewModel.recentFiles.collect { recentFiles ->
                     recentFilesAdapter.updateData(recentFiles)
                 }
+            }
+        }
+    }
+
+    private fun setupFilePicker() {
+        openPdfLauncher = registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+            uri?.let {
+                viewModel.handlePdf(it, requireContext())
+            } ?: run {
+                Toast.makeText(requireContext(), "PDF 선택 취소됨", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesViewModel.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesViewModel.kt
@@ -1,15 +1,25 @@
 package com.iguana.dashBoard
 
+import android.content.Context
+import android.content.Intent
+import android.graphics.pdf.PdfRenderer
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.provider.OpenableColumns
+import android.util.Log
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.iguana.data.local.entity.RecentFileEntity
 import com.iguana.domain.model.RecentFile
 import com.iguana.domain.repository.RecentFileRepository
+import com.iguana.notetaking.NotetakingActivity
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.io.File
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,7 +32,6 @@ class RecentFilesViewModel @Inject constructor(
 
     init {
         loadRecentFiles()
-        addDummyData()
     }
 
     private fun loadRecentFiles() {
@@ -36,12 +45,42 @@ class RecentFilesViewModel @Inject constructor(
     private fun addDummyData() {
         viewModelScope.launch {
             val dummyFiles = listOf(
-                RecentFileEntity("1", "바이오 빅데이터.pdf", "file:///dummy/path1", System.currentTimeMillis(), 1),
-                RecentFileEntity("2", "기계학습.pdf", "file:///dummy/path2", System.currentTimeMillis() - 86400000, 3),
-                RecentFileEntity("3", "유전체 정보학.pdf", "file:///dummy/path3", System.currentTimeMillis() - 172800000, null),
-                RecentFileEntity("4", "의생명 정보과학.pdf", "file:///dummy/path4", System.currentTimeMillis() - 259200000, 5)
+                RecentFileEntity(
+                    "1",
+                    "바이오 빅데이터.pdf",
+                    "file:///dummy/path1",
+                    System.currentTimeMillis(),
+                    1
+                ),
+                RecentFileEntity(
+                    "2",
+                    "기계학습.pdf",
+                    "file:///dummy/path2",
+                    System.currentTimeMillis() - 86400000,
+                    3
+                ),
+                RecentFileEntity(
+                    "3",
+                    "유전체 정보학.pdf",
+                    "file:///dummy/path3",
+                    System.currentTimeMillis() - 172800000,
+                    null
+                ),
+                RecentFileEntity(
+                    "4",
+                    "의생명 정보과학.pdf",
+                    "file:///dummy/path4",
+                    System.currentTimeMillis() - 259200000,
+                    5
+                )
             )
-            dummyFiles.forEach { recentFileRepository.insertRecentFile(it.id, it.fileName, it.fileUri) }
+            dummyFiles.forEach {
+                recentFileRepository.insertRecentFile(
+                    it.id,
+                    it.fileName,
+                    it.fileUri
+                )
+            }
         }
     }
 
@@ -62,5 +101,73 @@ class RecentFilesViewModel @Inject constructor(
         viewModelScope.launch {
             recentFileRepository.cleanupOldFiles(daysToKeep)
         }
+    }
+
+
+    // PDF 파일 선택 처리
+    fun handlePdf(uri: Uri?, context: Context) {
+        if (uri != null) {
+            val fileName = getFileName(context, uri)
+
+            viewModelScope.launch {
+                recentFileRepository.insertRecentFile(
+                    uri.toString(),
+                    fileName,
+                    uri.toString()
+                ) // Save recent file
+                getPdfMetadata(context, uri)
+
+                // 선택된 파일을 NotetakingActivity로 전달
+                val intent = Intent(context, NotetakingActivity::class.java).apply {
+                    putExtra("PDF_URI", uri.toString())
+                    putExtra("PDF_TITLE", fileName)
+                }
+                context.startActivity(intent)
+            }
+        }
+    }
+
+    // PDF 메타데이터 가져오기
+    private fun getPdfMetadata(context: Context, uri: Uri) {
+        val fileDescriptor: ParcelFileDescriptor? =
+            context.contentResolver.openFileDescriptor(uri, "r")
+        fileDescriptor?.use {
+            val fileSize = File(uri.path).length()  // 파일 크기
+            val fileName = File(uri.path).name      // 파일 이름
+            val lastModified = File(uri.path).lastModified() // 마지막 수정일
+            val renderer = PdfRenderer(it)
+            val pageCount = renderer.pageCount     // 페이지 수
+
+            // 로그에 PDF 정보 출력
+            Log.d(
+                "PDF_INFO",
+                "파일 이름: $fileName, 파일 크기: $fileSize, 페이지 수: $pageCount, 마지막 수정일: $lastModified"
+            )
+
+            renderer.close()
+        } ?: Toast.makeText(context, "PDF 파일을 열 수 없습니다.", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun getFileName(context: Context, uri: Uri): String {
+        var result: String? = null
+        if (uri.scheme == "content") {
+            val cursor = context.contentResolver.query(uri, null, null, null, null)
+            try {
+                if (cursor != null && cursor.moveToFirst()) {
+                    result =
+                        cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+                }
+            } finally {
+                cursor?.close()
+            }
+        }
+        if (result == null) {
+            result = uri.path
+            val cut = result?.lastIndexOf('/')
+            if (cut != null && cut != -1) {
+                result = result?.substring(cut + 1)
+            }
+        }
+        return result ?: "unknown"
     }
 }

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesViewModel.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesViewModel.kt
@@ -3,7 +3,8 @@ package com.iguana.dashboard
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.iguana.data.local.entity.RecentFileEntity
-import com.iguana.data.local.repository.RecentFileRepository
+import com.iguana.domain.model.RecentFile
+import com.iguana.domain.repository.RecentFileRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,8 +17,8 @@ class RecentFilesViewModel @Inject constructor(
     private val recentFileRepository: RecentFileRepository
 ) : ViewModel() {
 
-    private val _recentFiles = MutableStateFlow<List<RecentFileEntity>>(emptyList())
-    val recentFiles: StateFlow<List<RecentFileEntity>> = _recentFiles.asStateFlow()
+    private val _recentFiles = MutableStateFlow<List<RecentFile>>(emptyList())
+    val recentFiles: StateFlow<List<RecentFile>> = _recentFiles.asStateFlow()
 
     init {
         loadRecentFiles()

--- a/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesViewModel.kt
+++ b/feature/dashBoard/src/main/java/com/iguana/dashBoard/RecentFilesViewModel.kt
@@ -1,4 +1,4 @@
-package com.iguana.dashboard
+package com.iguana.dashBoard
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/feature/dashBoard/src/main/res/layout-land/activity_dash_borad_fragment.xml
+++ b/feature/dashBoard/src/main/res/layout-land/activity_dash_borad_fragment.xml
@@ -6,7 +6,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.iguana.dashboard.DashBoradFragment">
+    tools:context="com.iguana.dashBoard.DashBoradFragment">
 
     <TextView
         android:id="@+id/tv_dashboard"

--- a/feature/dashBoard/src/main/res/layout-sw600dp/activity_dash_borad_fragment.xml
+++ b/feature/dashBoard/src/main/res/layout-sw600dp/activity_dash_borad_fragment.xml
@@ -6,7 +6,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.iguana.dashboard.DashBoradFragment">
+    tools:context="com.iguana.dashBoard.DashBoradFragment">
 
     <TextView
         android:id="@+id/tv_dashboard"

--- a/feature/dashBoard/src/main/res/layout/activity_dash_borad_fragment.xml
+++ b/feature/dashBoard/src/main/res/layout/activity_dash_borad_fragment.xml
@@ -6,6 +6,6 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.iguana.dashboard.DashBoradFragment">
+    tools:context="com.iguana.dashBoard.DashBoradFragment">
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/dashBoard/src/main/res/layout/fragment_recent_files.xml
+++ b/feature/dashBoard/src/main/res/layout/fragment_recent_files.xml
@@ -1,40 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+<LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal">
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:tools="http://schemas.android.com/tools"
+        <LinearLayout
+            android:id="@+id/loadFileButton"
             android:layout_width="160dp"
             android:layout_height="200dp"
+            android:layout_margin="10dp"
             android:background="@drawable/file_item_background"
+            android:clickable="true"
             android:elevation="2dp"
             android:gravity="center"
             android:orientation="vertical"
             android:padding="16dp"
-            android:layout_margin="10dp"
-            tools:ignore="MissingDefaultResource">
+            android:focusable="true">
 
             <!-- Plus 아이콘 -->
             <ImageView
                 android:id="@+id/plusIcon"
                 android:layout_width="48dp"
                 android:layout_height="48dp"
+                android:padding="10dp"
+                android:clickable="true"
                 android:layout_gravity="center"
                 android:src="@drawable/ic_plus48_inactive" />
 
             <!-- 텍스트 정보 -->
             <TextView
                 android:id="@+id/loadLectureText"
+                style="@style/Regular8"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
                 android:gravity="center"
-                android:text="강의자료 불러오기"
-                style="@style/Regular8"
-                />
+                android:text="강의자료 불러오기" />
         </LinearLayout>
 
         <androidx.recyclerview.widget.RecyclerView
@@ -43,6 +47,5 @@
             android:layout_height="wrap_content"
             android:layout_weight="4"
             android:orientation="horizontal" />
-
     </LinearLayout>
 </layout>

--- a/feature/dashBoard/src/main/res/values/themes.xml
+++ b/feature/dashBoard/src/main/res/values/themes.xml
@@ -1,16 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.Notai" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/feature/dashBoard/src/test/java/com/iguana/dashBoard/ExampleUnitTest.kt
+++ b/feature/dashBoard/src/test/java/com/iguana/dashBoard/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.iguana.dashboard
+package com.iguana.dashBoard
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/feature/notetaking/src/main/java/com/iguana/notetaking/NotetakingActivity.kt
+++ b/feature/notetaking/src/main/java/com/iguana/notetaking/NotetakingActivity.kt
@@ -3,12 +3,10 @@ package com.iguana.notetaking
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
-import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.iguana.notetaking.databinding.ActivityNotetakingBinding
-import com.iguana.notetaking.databinding.ActivitySampleFilePickerBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 
@@ -30,6 +28,10 @@ class NotetakingActivity : AppCompatActivity() {
         val pdfTitle = intent.getStringExtra("PDF_TITLE") ?: "무제"
 
         binding.titleBar.titleBar.text = pdfTitle
+        // 뒤로가기 버튼 클릭 리스너 설정
+        binding.titleBar.backButton.setOnClickListener {
+            finish()
+        }
 
         if (pdfUriString != null) {
             val pdfUri = Uri.parse(pdfUriString)

--- a/feature/notetaking/src/main/java/com/iguana/notetaking/SampleFilePickerActivity.kt
+++ b/feature/notetaking/src/main/java/com/iguana/notetaking/SampleFilePickerActivity.kt
@@ -11,8 +11,9 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.viewModels
 import com.iguana.notetaking.databinding.ActivitySampleFilePickerBinding
+import dagger.hilt.android.AndroidEntryPoint
 
-
+@AndroidEntryPoint
 class SampleFilePickerActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySampleFilePickerBinding
     private lateinit var openPdfLauncher: ActivityResultLauncher<Array<String>>
@@ -31,7 +32,7 @@ class SampleFilePickerActivity : AppCompatActivity() {
             registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
                 if (uri != null) {
                     // PDF 파일 처리 로직 호출
-                    viewModel.handlePdf(uri)
+                    viewModel.handlePdf(uri, this)
 
                     // PDF 파일의 이름을 정확히 가져오기
                     val fileName = viewModel.getFileName(this, uri)

--- a/feature/notetaking/src/main/res/layout-sw600dp/titlebar.xml
+++ b/feature/notetaking/src/main/res/layout-sw600dp/titlebar.xml
@@ -11,6 +11,7 @@
 
         <!-- 뒤로가기 Button -->
         <ImageButton
+            android:id="@+id/backButton"
             android:layout_width="25dp"
             android:layout_height="25dp"
             android:background="@drawable/ic_left_inactive" />

--- a/feature/notetaking/src/main/res/layout/titlebar.xml
+++ b/feature/notetaking/src/main/res/layout/titlebar.xml
@@ -11,6 +11,7 @@
 
         <!-- 뒤로가기 버튼 TODO: 이벤트 정의하기 -->
         <ImageButton
+            android:id="@+id/backButton"
             android:layout_width="25dp"
             android:layout_height="25dp"
             android:background="@drawable/ic_left_inactive" />


### PR DESCRIPTION
## 🔎 작업 내용

> SampleFilePicker 에서 pdf 파일을 열 때, 이를 Room RecentFile Database 에 저장한다.
> - SaveRecentFileUsecase 추가 
> - 파일을 열면 SaveRecentFileUsecase 호출 -> RecentFileRepository -> RecentFileDao 로 데이터 저장 및 접근
> - 현재는 SampleFilePicker에서 진행되었지만 대시보드와 필기 화면을 연결할 시에 이를 대시보드에서 가능하도록 하겠습니다.


## 💬 리뷰 요구사항 (선택)

> 유스케이스를 추가하는 과정에서 core:data 및 core:domain 코드의 수정이 있습니다. 확인 부탁드립니다.
> 주요 수정 사항
> - data layer 에 있던 repository 를 추상 인터페이스와 구현체로 분리하여 domain 레이어에는 인터페이스를 위치시키고 data 레이어에 구현체를 위치 시켰습니다. 
> - domain model 을 따로 구현하여(RecentFile) presentation 레이어와 domain layer 에서는 data 레이어의 Entity 를 모르도록 리팩토링 하였습니다. 
> - 이 과정에서 Entity-Domain Model 의 매퍼 함수를  추가하였습니다.
> 이해 안가는 코드 및 개선 사항이 있다면 코멘트 부탁드립니다!


## 📸 이미지 첨부 (선택)
- 에뮬레이터 테스트 결과입니다.
> - lastOpened 에 들어가는 데이터에 대한 수정이 필요할 것 같긴합니다, id 에는 서버와의 통신이 현재 없기 때문에 일단은 uri 를 넣었습니다.
<img width="1432" alt="스크린샷 2024-09-30 오전 11 01 45" src="https://github.com/user-attachments/assets/9910d00d-0c88-451e-8a70-346d2c8eba98">
- 피드백 받은대로 대시보드와 필기화면 연결하고 최근 파일 더미데이터 삽입 부분 삭제했습니다! (2024.09.30.)

https://github.com/user-attachments/assets/3330b4f1-e5c2-4563-b6b0-07eff14be70d



## ➕ 이슈 링크

-  #24
