### PR TITLE
[Feat] 문서 관련 API 정의, 문서 관련 레포지토리 추상체&구현체 구현

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="selectedTabId" value="Android Vitals" />
+  </component>
+</project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -10,12 +10,12 @@
               <deviceKey>
                 <Key>
                   <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="C:\Users\edwin\.android\avd\Pixel_Tablet_API_30.avd" />
+                  <value value="C:\Users\edwin\.android\avd\Pixel_4_API_30.avd" />
                 </Key>
               </deviceKey>
             </Target>
           </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-10-01T07:01:08.070247700Z" />
+          <timeTargetWasSelectedWithDropDown value="2024-10-01T14:05:34.789623800Z" />
         </State>
       </entry>
     </value>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:name=".NotaiApplication"
         android:allowBackup="true"

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
     implementation(libs.room.runtime)
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
     implementation(projects.core.domain) // domain 에 있는 걸 구현하므로
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
 }

--- a/core/data/src/main/java/com/iguana/data/mapper/DocumentsMapper.kt
+++ b/core/data/src/main/java/com/iguana/data/mapper/DocumentsMapper.kt
@@ -1,0 +1,26 @@
+package com.iguana.data.mapper
+
+import com.iguana.data.remote.model.*
+import com.iguana.domain.model.*
+
+// DTO to Domain
+fun DocumentDto.toDomain() = Document(id, folderId, name, url, pageCount, updatedAt)
+
+fun FolderContentResponseDto.toDomain() = FolderContent(
+    content.map { it.toDomain() },
+    totalElements,
+    currentPage,
+    totalPages,
+    sortBy,
+    sortDirection
+)
+fun FolderContentDto.toDomain() = FolderContentItem(type, id, name, updatedAt, totalElements)
+
+fun CreateFolderResponseDto.toDomain() = Folder(id, parentId, name)
+
+// Domain to DTO
+fun Document.toDto() = DocumentDto(id, folderId, name, url, pageCount, updatedAt)
+
+fun Folder.toCreateFolderRequestDto() = CreateFolderRequestDto(name)
+
+fun MoveItemsRequest.toDto() = MoveFolderRequestDto(documentIds, folderIds, destinationFolderId)

--- a/core/data/src/main/java/com/iguana/data/remote/api/DocumentApi.kt
+++ b/core/data/src/main/java/com/iguana/data/remote/api/DocumentApi.kt
@@ -1,0 +1,54 @@
+package com.iguana.data.remote.api
+
+import com.iguana.data.remote.model.CreateFolderRequestDto
+import com.iguana.data.remote.model.CreateFolderResponseDto
+import com.iguana.data.remote.model.DocumentDto
+import com.iguana.data.remote.model.FolderContentResponseDto
+import com.iguana.data.remote.model.MoveFolderRequestDto
+import okhttp3.MultipartBody
+import retrofit2.http.*
+
+interface DocumentApi {
+    @Multipart
+    @POST("/api/folders/{folderId}/document")
+    suspend fun uploadDocument(
+        @Path("folderId") folderId: Long,
+        @Part file: MultipartBody.Part
+    ): DocumentDto
+
+    @GET("/api/folders/{folderId}")
+    suspend fun getFolderContents(
+        @Path("folderId") folderId: Long?,
+        @Query("page") page: Int = 1,
+        @Query("size") size: Int = 20,
+        @Query("sortBy") sortBy: String = "updatedAt",
+        @Query("sortDirection") sortDirection: String = "desc"
+    ): FolderContentResponseDto
+
+    @GET("/api/documents")
+    suspend fun getDocuments(@Query("documentIds") documentIds: List<Long>): List<DocumentDto>
+
+    @GET("/api/documents/{documentId}")
+    suspend fun getDocumentDetails(@Path("documentId") documentId: Long): DocumentDto
+
+    @PUT("/api/documents/{documentId}/name")
+    suspend fun updateDocumentName(
+        @Path("documentId") documentId: Long,
+        @Body name: Map<String, String>
+    ): DocumentDto
+
+    @DELETE("/api/documents/{documentId}")
+    suspend fun deleteDocument(@Path("documentId") documentId: Long)
+
+    @POST("/api/folders/{parentFolderId}")
+    suspend fun createFolder(
+        @Path("parentFolderId") parentFolderId: Long,
+        @Body request: CreateFolderRequestDto
+    ): CreateFolderResponseDto
+
+    @DELETE("/api/folders/{folderId}")
+    suspend fun deleteFolder(@Path("folderId") folderId: Long)
+
+    @POST("/api/folders/move")
+    suspend fun moveItems(@Body request: MoveFolderRequestDto): MoveFolderRequestDto
+}

--- a/core/data/src/main/java/com/iguana/data/remote/model/DocumentsDto.kt
+++ b/core/data/src/main/java/com/iguana/data/remote/model/DocumentsDto.kt
@@ -1,0 +1,43 @@
+package com.iguana.data.remote.model
+
+data class DocumentDto(
+    val id: Long,
+    val folderId: Long?,
+    val name: String,
+    val url: String?,
+    val pageCount: Int?,
+    val updatedAt: String
+)
+
+data class FolderContentDto(
+    val type: String,
+    val id: Long,
+    val name: String,
+    val updatedAt: String,
+    val totalElements: Int
+)
+
+data class FolderContentResponseDto(
+    val content: List<FolderContentDto>,
+    val totalElements: Int,
+    val currentPage: Int,
+    val totalPages: Int,
+    val sortBy: String,
+    val sortDirection: String
+)
+
+data class CreateFolderRequestDto(
+    val name: String
+)
+
+data class CreateFolderResponseDto(
+    val id: Long,
+    val parentId: Long,
+    val name: String
+)
+
+data class MoveFolderRequestDto(
+    val documentIds: List<Long>,
+    val folderIds: List<Long>,
+    val destinationFolderId: Long
+)

--- a/core/data/src/main/java/com/iguana/data/repository/DocumentsRepositoyImpl.kt
+++ b/core/data/src/main/java/com/iguana/data/repository/DocumentsRepositoyImpl.kt
@@ -1,0 +1,112 @@
+package com.iguana.data.repository
+
+import android.content.Context
+import com.iguana.data.mapper.toDomain
+import com.iguana.data.mapper.toDto
+import com.iguana.data.remote.api.DocumentApi
+import com.iguana.data.remote.model.CreateFolderRequestDto
+import com.iguana.domain.model.Document
+import com.iguana.domain.model.Folder
+import com.iguana.domain.model.FolderContent
+import com.iguana.domain.model.MoveItemsRequest
+import com.iguana.domain.repository.DocumentsRepository
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+import javax.inject.Inject
+import retrofit2.HttpException
+
+class DocumentsRepositoryImpl @Inject constructor(
+    private val context: Context,
+    private val api: DocumentApi
+) : DocumentsRepository {
+
+    override suspend fun uploadDocument(folderId: Long, file: File): Result<Document> = try {
+        val requestFile = file.asRequestBody("application/pdf".toMediaTypeOrNull())
+        val body = MultipartBody.Part.createFormData("file", file.name, requestFile)
+        val response = api.uploadDocument(folderId, body)
+        Result.success(response.toDomain())
+    } catch (e: HttpException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    override suspend fun getFolderContents(folderId: Long?, page: Int, size: Int, sortBy: String, sortDirection: String): Result<FolderContent> = try {
+        val response = api.getFolderContents(folderId, page, size, sortBy, sortDirection)
+        Result.success(response.toDomain())
+    } catch (e: HttpException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    override suspend fun getDocuments(documentIds: List<Long>): Result<List<Document>> = try {
+        val response = api.getDocuments(documentIds)
+        Result.success(response.map { it.toDomain() })
+    } catch (e: HttpException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    override suspend fun getDocumentDetails(documentId: Long): Result<Document> = try {
+        val response = api.getDocumentDetails(documentId)
+        Result.success(response.toDomain())
+    } catch (e: HttpException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    override suspend fun updateDocumentName(documentId: Long, name: String): Result<Document> = try {
+        val response = api.updateDocumentName(documentId, mapOf("name" to name))
+        Result.success(response.toDomain())
+    } catch (e: HttpException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    override suspend fun deleteDocument(documentId: Long): Result<Unit> = try {
+        api.deleteDocument(documentId)
+        Result.success(Unit)
+    } catch (e: HttpException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    override suspend fun createFolder(parentFolderId: Long, name: String): Result<Folder> = try {
+        val request = CreateFolderRequestDto(name)
+        val response = api.createFolder(parentFolderId, request)
+        Result.success(response.toDomain())
+    } catch (e: HttpException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    override suspend fun deleteFolder(folderId: Long): Result<Unit> = try {
+        api.deleteFolder(folderId)
+        Result.success(Unit)
+    } catch (e: HttpException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    override suspend fun moveItems(request: MoveItemsRequest): Result<Unit> = try {
+        api.moveItems(request.toDto())
+        Result.success(Unit)
+    } catch (e: HttpException) {
+        Result.failure(e)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    companion object {
+        private const val TAG = "DocumentsRepositoryImpl"
+    }
+}

--- a/core/domain/src/main/java/com/iguana/domain/model/Document.kt
+++ b/core/domain/src/main/java/com/iguana/domain/model/Document.kt
@@ -1,0 +1,39 @@
+package com.iguana.domain.model
+
+data class Document(
+    val id: Long,
+    val folderId: Long?,
+    val name: String,
+    val url: String?,
+    val pageCount: Int?,
+    val updatedAt: String
+)
+
+data class FolderContent(
+    val content: List<FolderContentItem>,
+    val totalElements: Int,
+    val currentPage: Int,
+    val totalPages: Int,
+    val sortBy: String,
+    val sortDirection: String
+)
+
+data class FolderContentItem(
+    val type: String,
+    val id: Long,
+    val name: String,
+    val updatedAt: String,
+    val totalElements: Int
+)
+
+data class Folder(
+    val id: Long,
+    val parentId: Long,
+    val name: String
+)
+
+data class MoveItemsRequest(
+    val documentIds: List<Long>,
+    val folderIds: List<Long>,
+    val destinationFolderId: Long
+)

--- a/core/domain/src/main/java/com/iguana/domain/repository/DocumentsRepository.kt
+++ b/core/domain/src/main/java/com/iguana/domain/repository/DocumentsRepository.kt
@@ -1,0 +1,16 @@
+package com.iguana.domain.repository
+
+import com.iguana.domain.model.*
+import java.io.File
+
+interface DocumentsRepository {
+    suspend fun uploadDocument(folderId: Long, file: File): Result<Document>
+    suspend fun getFolderContents(folderId: Long?, page: Int, size: Int, sortBy: String, sortDirection: String): Result<FolderContent>
+    suspend fun getDocuments(documentIds: List<Long>): Result<List<Document>>
+    suspend fun getDocumentDetails(documentId: Long): Result<Document>
+    suspend fun updateDocumentName(documentId: Long, name: String): Result<Document>
+    suspend fun deleteDocument(documentId: Long): Result<Unit>
+    suspend fun createFolder(parentFolderId: Long, name: String): Result<Folder>
+    suspend fun deleteFolder(folderId: Long): Result<Unit>
+    suspend fun moveItems(request: MoveItemsRequest): Result<Unit>
+}


### PR DESCRIPTION
## 🔎 작업 내용

> API를 정의하고, Reopsitory를 만들어 해당 Repository를 Impl에서 구체화하였습니다.
API만 하니까 작업단위가 조금 작은 것 같아. 다음 Issue까지 한번에 보냈습니다.
양은 조금 많았는데 작업 단위 나눠서 각각을 테스트해보기가 애매해서 한번에 보냈습니다!

## 💬 리뷰 요구사항 (선택)

> Chunker로 테스트 해보려고 했으나, Chunker가 기기에서 알림형태로 뜨지 않아 테스트 해보지 못하고 pr 보냅니다.
추후 백엔드와 연결 후 실제 테스트 진행해야 할 수도 있을 것 같습니다.
한번 확인부탁드립니다!

## 📸 이미지 첨부 (선택)



## ➕ 이슈 링크
- #41 
- #42 
